### PR TITLE
Added controlTextDidEndEditing to delegate

### DIFF
--- a/Sources/CatalystAdditions/SearchToolbarItem.swift
+++ b/Sources/CatalystAdditions/SearchToolbarItem.swift
@@ -52,5 +52,6 @@ extension SearchToolbarItem: WrapNSSearchFieldDelegate {
     @objc optional func searchFieldDidStartSearching(_ sender: Any)
     @objc optional func searchFieldDidEndSearching(_ sender: Any)
     @objc optional func controlTextDidChange(_ obj: Notification)
+    @objc optional func controlTextDidEndEditing(_ obj: Notification)
 }
 #endif


### PR DESCRIPTION
I've added controlTextDidEndEditing to the WrapNSSearchFieldDelegate. It's called when the user presses the Return/Enter key on their Mac which the other methods didn't support.