### PR TITLE
Added textChanged and textReturned to the search field

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CatalystAdditions.xcodeproj/project.pbxproj
+++ b/CatalystAdditions.xcodeproj/project.pbxproj
@@ -393,10 +393,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Example/Preview Content\"";
-				DEVELOPMENT_TEAM = DP9Q5R8635;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -416,10 +417,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Example/Preview Content\"";
-				DEVELOPMENT_TEAM = DP9Q5R8635;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -623,7 +625,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = DP9Q5R8635;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/CatalystAdditionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -644,7 +646,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = DP9Q5R8635;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/CatalystAdditionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Example/SceneDelegate.swift
+++ b/Example/SceneDelegate.swift
@@ -84,9 +84,12 @@ extension SceneDelegate: NSToolbarDelegate {
     func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
         switch itemIdentifier {
         case .search:
-            let item = SearchToolbarItem(itemIdentifier: .search) { text in
-                print(text)
+            let item = SearchToolbarItem(itemIdentifier: Toolbar.search, textChanged: { (textChanged) in
+                print(textChanged)
+            }) { (textReturned) in
+                print(textReturned)
             }
+            
             return item
         default:
             return nil

--- a/Example/SceneDelegate.swift
+++ b/Example/SceneDelegate.swift
@@ -84,7 +84,7 @@ extension SceneDelegate: NSToolbarDelegate {
     func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
         switch itemIdentifier {
         case .search:
-            let item = SearchToolbarItem(itemIdentifier: Toolbar.search, textChanged: { (textChanged) in
+            let item = SearchToolbarItem(itemIdentifier: .search, textChanged: { (textChanged) in
                 print(textChanged)
             }) { (textReturned) in
                 print(textReturned)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ import CatalystAdditions
 let item = SearchToolbarItem(itemIdentifier: .search) { text in
     // do something
 }
+let item = SearchToolbarItem(itemIdentifier: .search, textChanged: { (textChanged) in
+    // update search results as the user is typing
+}) { (textReturned) in
+    // update search results only after return/enter key is pressed
+}
 ```
 <details><summary>Screenshot</summary>
 

--- a/Sources/CatalystAdditions/SearchToolbarItem.swift
+++ b/Sources/CatalystAdditions/SearchToolbarItem.swift
@@ -12,11 +12,14 @@ import SwiftUI
 @available(iOS, deprecated: 14.0, message: "There is a possibility that new method have been added to Apple's framework. If so, you should use it.")
 public final class SearchToolbarItem: NSToolbarItem {
     public typealias TextChanged = ((String) -> Void)
+    public typealias TextReturned = ((String) -> Void)
 
     private let textChanged: TextChanged
+    private let textReturned: TextReturned
 
-    public init(itemIdentifier: NSToolbarItem.Identifier, textChanged: @escaping TextChanged) {
+    public init(itemIdentifier: NSToolbarItem.Identifier, textChanged: @escaping TextChanged, textReturned: @escaping TextReturned) {
         self.textChanged = textChanged
+        self.textReturned = textReturned
         super.init(itemIdentifier: itemIdentifier)
 
         self.label = "Search"
@@ -45,6 +48,14 @@ extension SearchToolbarItem: WrapNSSearchFieldDelegate {
             return
         }
         textChanged(text)
+    }
+    
+    func controlTextDidEndEditing(_ notification: Notification) {
+        guard let notificationDictionary = notification.userInfo,
+        notificationDictionary["_NSFirstResponderReplacingFieldEditor"] == nil,
+        let text = getSearchText(notification.object) else { return }
+        
+        textReturned(text)
     }
 }
 


### PR DESCRIPTION
This provides users with two options when adding the search field to their toolbar:

textChanged: This is updated as the user types to load search results whilst typing characters.

textReturned: This is only called when the user presses their return key. I've added a guard statement to ensure it's not called when clicking off of the text field or pressing the clear button as it would without it.